### PR TITLE
adding option to add/commit

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -7,6 +7,8 @@ the default configuration with the following parameters:
 * `branch` - Target remote branch, defaults to master
 * `force` - Force push using the `--force` flag, defaults to false
 * `skip_verify` - Skip verification of HTTPS certs, defaults to false
+* `add` - Add the contents of the repo before pushing, defaults to false
+* `commit` - Commit the contents of the repo before pushing, defaults to false
 
 ## Example
 
@@ -18,4 +20,6 @@ deploy:
     branch: master
     remote: git@git.heroku.com:falling-wind-1624.git
     force: false
+    add: true
+    commit: true
 ```

--- a/DOCS.md
+++ b/DOCS.md
@@ -7,8 +7,7 @@ the default configuration with the following parameters:
 * `branch` - Target remote branch, defaults to master
 * `force` - Force push using the `--force` flag, defaults to false
 * `skip_verify` - Skip verification of HTTPS certs, defaults to false
-* `add` - Add the contents of the repo before pushing, defaults to false
-* `commit` - Commit the contents of the repo before pushing, defaults to false
+* `commit` - Add and commit the contents of the repo before pushing, defaults to false
 
 ## Example
 
@@ -20,6 +19,5 @@ deploy:
     branch: master
     remote: git@git.heroku.com:falling-wind-1624.git
     force: false
-    add: true
     commit: true
 ```

--- a/main.go
+++ b/main.go
@@ -64,6 +64,20 @@ func run(workspace *drone.Workspace, build *drone.Build, vargs *Params) error {
 		return err
 	}
 
+	if vargs.Add {
+		cmd = repo.ForceAdd()
+		if err := execute(cmd, workspace); err != nil {
+			return err
+		}
+	}
+
+	if vargs.Commit {
+		cmd = repo.ForceCommit()
+		if err := execute(cmd, workspace); err != nil {
+			return err
+		}
+	}
+
 	cmd = repo.RemotePush(
 		"deploy",
 		vargs.Branch,

--- a/main.go
+++ b/main.go
@@ -64,14 +64,12 @@ func run(workspace *drone.Workspace, build *drone.Build, vargs *Params) error {
 		return err
 	}
 
-	if vargs.Add {
+	if vargs.Commit {
 		cmd = repo.ForceAdd()
 		if err := execute(cmd, workspace); err != nil {
 			return err
 		}
-	}
 
-	if vargs.Commit {
 		cmd = repo.ForceCommit()
 		if err := execute(cmd, workspace); err != nil {
 			return err

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -18,7 +18,7 @@ func ForceCommit() *exec.Cmd {
 	cmd := exec.Command(
 		"git",
 		"commit",
-		"-m 'Commit dirty state'")
+		"-m 'Commit dirty state [ci skip]'") // skip the CI build since this commit was triggered by the build system, not by a user
 
 	return cmd
 }

--- a/repo/commit.go
+++ b/repo/commit.go
@@ -18,7 +18,7 @@ func ForceCommit() *exec.Cmd {
 	cmd := exec.Command(
 		"git",
 		"commit",
-		"-m 'Commit dirty state [ci skip]'") // skip the CI build since this commit was triggered by the build system, not by a user
+		"-m '[skip ci] Commit dirty state'") // skip the CI build since this commit was triggered by the build system, not by a user
 
 	return cmd
 }

--- a/types.go
+++ b/types.go
@@ -5,6 +5,5 @@ type Params struct {
 	Branch     string `json:"branch"`
 	Force      bool   `json:"force"`
 	SkipVerify bool   `json:"skip_verify"`
-        Add        bool   `json:"add"`
-        Commit     bool   `json:"commit"`
+    Commit     bool   `json:"commit"`
 }

--- a/types.go
+++ b/types.go
@@ -5,5 +5,5 @@ type Params struct {
 	Branch     string `json:"branch"`
 	Force      bool   `json:"force"`
 	SkipVerify bool   `json:"skip_verify"`
-    Commit     bool   `json:"commit"`
+	Commit     bool   `json:"commit"`
 }

--- a/types.go
+++ b/types.go
@@ -5,4 +5,6 @@ type Params struct {
 	Branch     string `json:"branch"`
 	Force      bool   `json:"force"`
 	SkipVerify bool   `json:"skip_verify"`
+        Add        bool   `json:"add"`
+        Commit     bool   `json:"commit"`
 }


### PR DESCRIPTION
This adds the option to perform an add or commit before doing the push. This is useful if previous build steps modify state in the repo, such as checking in state files.