### PR TITLE
Add support for finer-tuned push controls.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,8 +3,10 @@
 Use this plugin for deplying an application via `git push`. You can override
 the default configuration with the following parameters:
 
-* `remote` - Target remote repository
+* `remote` - Target remote repository (if blank, assume exists)
+* `remote_name` - Name of the remote to use locally (default "deploy")
 * `branch` - Target remote branch, defaults to master
+* `local_branch` - Local branch or ref to push (default "HEAD")
 * `force` - Force push using the `--force` flag, defaults to false
 * `skip_verify` - Skip verification of HTTPS certs, defaults to false
 * `commit` - Add and commit the contents of the repo before pushing, defaults to false
@@ -20,4 +22,14 @@ deploy:
     remote: git@git.heroku.com:falling-wind-1624.git
     force: false
     commit: true
+```
+
+An example of pushing a branch back to the current repository:
+
+```yaml
+deploy:
+  git_push:
+    remote_name: origin
+    branch: gh-pages
+    local_ref: gh-pages
 ```

--- a/repo/key.go
+++ b/repo/key.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -8,6 +9,12 @@ import (
 
 	"github.com/drone/drone-go/drone"
 )
+
+const netrcFile = `
+machine %s
+login %s
+password %s
+`
 
 func WriteKey(workspace *drone.Workspace) error {
 	if workspace.Keys == nil || len(workspace.Keys.Private) == 0 {
@@ -45,4 +52,24 @@ func WriteKey(workspace *drone.Workspace) error {
 		privpath,
 		[]byte(workspace.Keys.Private),
 		0600)
+}
+
+// Writes the netrc file.
+func WriteNetrc(in *drone.Workspace) error {
+	if in.Netrc == nil || len(in.Netrc.Machine) == 0 {
+		return nil
+	}
+	out := fmt.Sprintf(
+		netrcFile,
+		in.Netrc.Machine,
+		in.Netrc.Login,
+		in.Netrc.Password,
+	)
+	home := "/root"
+	u, err := user.Current()
+	if err == nil {
+		home = u.HomeDir
+	}
+	path := filepath.Join(home, ".netrc")
+	return ioutil.WriteFile(path, []byte(out), 0600)
 }

--- a/repo/remote.go
+++ b/repo/remote.go
@@ -26,11 +26,15 @@ func RemoteAdd(name, url string) *exec.Cmd {
 }
 
 func RemotePush(remote, branch string, force bool) *exec.Cmd {
+	return RemotePushNamedBranch(remote, "HEAD", branch, force)
+}
+
+func RemotePushNamedBranch(remote, localbranch string, branch string, force bool) *exec.Cmd {
 	cmd := exec.Command(
 		"git",
 		"push",
 		remote,
-		"HEAD:"+branch)
+		localbranch+":"+branch)
 
 	if force {
 		cmd.Args = append(

--- a/types.go
+++ b/types.go
@@ -1,9 +1,11 @@
 package main
 
 type Params struct {
-	Remote     string `json:"remote"`
-	Branch     string `json:"branch"`
-	Force      bool   `json:"force"`
-	SkipVerify bool   `json:"skip_verify"`
-	Commit     bool   `json:"commit"`
+	Remote      string `json:"remote"`
+	RemoteName  string `json:"remote_name"`
+	Branch      string `json:"branch"`
+	LocalBranch string `json:"local_branch"`
+	Force       bool   `json:"force"`
+	SkipVerify  bool   `json:"skip_verify"`
+	Commit      bool   `json:"commit"`
 }


### PR DESCRIPTION
Adds local_branch, remote_name parameters to allow customizing what gets pushed if your build steps may have been creating branches on their own.

Also adds support for writing the .netrc from the repository so push-back is possible over HTTP/HTTPS.

Finally, use the drone-plugin-go repository rather then drone one for implementation.

By default, the old behavior of the plugin is preserved.